### PR TITLE
Fix CLI prediction output

### DIFF
--- a/eth-market-forecasting/backend/ai_model/predict.py
+++ b/eth-market-forecasting/backend/ai_model/predict.py
@@ -91,4 +91,7 @@ def predict_eth_price():
 if __name__ == "__main__":
     logging.info("🚀 Running ETH Price Prediction...")
     predicted_price = predict_eth_price()
-    print(f"📈 Predicted ETH Price: ${predicted_price:.2f}" if predicted_price else "❌ Failed to generate prediction.")
+    if predicted_price is not None:
+        print(f"📈 Predicted ETH Price: ${predicted_price:.2f}")
+    else:
+        print("❌ Failed to generate prediction.")


### PR DESCRIPTION
## Summary
- handle zero-value predictions correctly in the CLI

## Testing
- `python -m py_compile eth-market-forecasting/backend/ai_model/predict.py`


------
https://chatgpt.com/codex/tasks/task_e_687d174e5850832788f367cd16dc044b