### PR TITLE
Add initial React dashboard scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ eth_forecast_model.pkl
 # Ignore macOS & Windows system files (just in case)
 .DS_Store
 Thumbs.db
+
+# Node modules
+node_modules/
+# Build output
+dist/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "eth-market-forecasting",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
+  },
+  "homepage": "https://MrBinnacle.github.io/eth-market-forecasting"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ETHForecastingDashboard from './ETHForecastingDashboard';
+
+function App() {
+  return <ETHForecastingDashboard />;
+}
+
+export default App;

--- a/src/DashboardStyles.css
+++ b/src/DashboardStyles.css
@@ -1,0 +1,52 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 100%);
+  color: #fff;
+  padding: 20px;
+  min-height: 100vh;
+}
+.container { max-width: 1400px; margin: auto; }
+.total-value {
+  font-size: 3rem;
+  font-weight: bold;
+  background: linear-gradient(45deg, #4facfe 0%, #00f2fe 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.status-indicator {
+  display: inline-block;
+  background: rgba(0, 255, 136, 0.2);
+  border: 1px solid #00ff88;
+  border-radius: 20px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  margin: 10px 0;
+}
+.total-return {
+  font-size: 1.2rem;
+  color: #00ff88;
+}
+.emergency-fund-status {
+  background: rgba(255, 170, 0, 0.2);
+  border: 1px solid #ffaa00;
+  border-radius: 10px;
+  padding: 15px;
+  margin: 20px 0;
+  text-align: center;
+}
+.threshold-input {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 5px;
+  padding: 10px;
+  color: white;
+  font-size: 1.1rem;
+  text-align: center;
+  width: 120px;
+}
+.update-time {
+  text-align: center;
+  color: #888;
+  font-size: 0.9rem;
+  margin-top: 20px;
+}

--- a/src/ETHForecastingDashboard.jsx
+++ b/src/ETHForecastingDashboard.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import './DashboardStyles.css';
+
+const ETHForecastingDashboard = () => (
+  <div className="container">
+    <div className="header">
+      <div className="total-value">$1,009.78</div>
+      <div className="status-indicator">🎓 Learning Portfolio Mode</div>
+      <div className="total-return">+$536.10 Total Return (113.3%)</div>
+      <div className="emergency-fund-status">
+        <strong>Emergency Fund Threshold:</strong>
+        <input type="number" className="threshold-input" value="5000" id="thresholdInput" />
+        <span style={{ fontSize: '0.9rem', display: 'block', marginTop: '5px' }}>
+          Current: 20% of threshold | Status: Play Money
+        </span>
+      </div>
+    </div>
+    <div className="update-time">Updated today • ETH Market Dashboard v1</div>
+  </div>
+);
+
+export default ETHForecastingDashboard;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/eth-market-forecasting/',
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- create new React dashboard component and styling
- wire into simple App.jsx
- add Vite config and deployment scripts in package.json
- update `.gitignore` for node artifacts

## Testing
- `pytest -q`
- `npm install gh-pages --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687ec7b1dce883279013378e3fa36bd3