### PR TITLE
Integrate Snyk scan and CI badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,9 @@ jobs:
           node-version: '18'
       - run: npm ci
       - run: npm run test
+      - name: "\ud83d\udd10 Run Snyk Security Audit"
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ETH Market Forecasting Dashboard
 
+[![CI](https://github.com/MrBinnacle/eth-market-forecasting/actions/workflows/ci.yml/badge.svg)](https://github.com/MrBinnacle/eth-market-forecasting/actions/workflows/ci.yml)
+[![Snyk](https://snyk.io/test/github/MrBinnacle/eth-market-forecasting/badge.svg)](https://snyk.io/test/github/MrBinnacle/eth-market-forecasting)
+
 This repository contains a small end‑to‑end system for forecasting the price of
 Ethereum.  Market data is fetched and stored in SQLite, a machine‐learning model
 is trained, and a simple dashboard displays predictions.  The React dashboard is
@@ -61,5 +64,11 @@ API_TIMEOUT=10
 
   ```bash
   npm run test
+  ```
+
+- **Security Scan** (Snyk)
+
+  ```bash
+  npx snyk test
   ```
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "homepage": "https://MrBinnacle.github.io/eth-market-forecasting",
   "devDependencies": {
     "gh-pages": "^5.0.0",
-    "vitest": "^1.3.0"
+    "vitest": "^1.3.0",
+    "snyk": "^1.1288.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Snyk to dev dependencies
- run Snyk audit in CI
- show CI and Snyk badges in README
- document how to run tests and security scan

## Testing
- `npm run test` *(fails: vitest not found)*
- `npx snyk test` *(fails: forbidden to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_687f9da0bed48327aee072f9c148a663